### PR TITLE
170 PotionEffects should have a way, to use the kotlin duration api instead of minecraft-ticks as a parameter

### DIFF
--- a/JET-Paper/src/main/kotlin/de/jet/paper/extension/effect/Potion.kt
+++ b/JET-Paper/src/main/kotlin/de/jet/paper/extension/effect/Potion.kt
@@ -1,0 +1,19 @@
+package de.jet.paper.extension.effect
+
+import de.jet.jvm.extension.time.inWholeMinecraftTicks
+import org.bukkit.potion.PotionEffect
+import org.bukkit.potion.PotionEffectType
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+fun PotionEffect(type: PotionEffectType, durationTicks: Int, amplifier: Int = 0, ambient: Boolean = true, particles: Boolean = true, icon: Boolean = true) =
+    PotionEffect(
+        /* type = */ type,
+        /* duration = */ durationTicks,
+        /* amplifier = */ amplifier,
+        /* ambient = */ ambient,
+        /* particles = */ particles,
+        /* icon = */ icon
+    )
+fun PotionEffect(type: PotionEffectType, duration: Duration = 10.seconds, amplifier: Int = 0, ambient: Boolean = true, particles: Boolean = true, icon: Boolean = true) =
+    PotionEffect(type, duration.inWholeMinecraftTicks.toInt(), amplifier, ambient, particles, icon)


### PR DESCRIPTION
closes #170