### PR TITLE
feature: added loadbefore to plugin.yml

### DIFF
--- a/MoltenKT-Paper/src/main/resources/plugin.yml
+++ b/MoltenKT-Paper/src/main/resources/plugin.yml
@@ -11,3 +11,7 @@ softdepend:
   - PlaceholderAPI
 prefix: ${name}
 website: ${website}
+loadbefore:
+  - SimpleCloud-Plugin
+depend:
+  - Kotlin


### PR DESCRIPTION
This addition to the plugin.yml fixes the critical error, when launching SimpleCloud and MoltenKT on a server.